### PR TITLE
add allowUnknown option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ func printStringPointer(s *string) string {
 
 func main() {
 	lsColors := os.Getenv("LS_COLORS")
-	result, err := lscolors.ParseLS_COLORS(lsColors)
+	result, err := lscolors.ParseLS_COLORS(lsColors, false)
 	if err != nil {
 		fmt.Printf("error: %s", err.Error())
 		return

--- a/example/main.go
+++ b/example/main.go
@@ -17,7 +17,7 @@ func printStringPointer(s *string) string {
 
 func main() {
 	lsColors := os.Getenv("LS_COLORS")
-	result, err := lscolors.ParseLS_COLORS(lsColors)
+	result, err := lscolors.ParseLS_COLORS(lsColors, false)
 	if err != nil {
 		fmt.Printf("error: %s", err.Error())
 		return


### PR DESCRIPTION
## 修正・解決されるissue

no-issue

## 目的

EXA_COLORS等の、LS_COLORSにはなかったフィールドをもつ類似のフォーマットを読めるようにしたい

## 変更点

未知のインディケータを受け入れるオプションを追加。
